### PR TITLE
Class names in singular

### DIFF
--- a/src/StringUtils.php
+++ b/src/StringUtils.php
@@ -37,7 +37,10 @@ abstract class StringUtils
             $table = self::removePrefix($table, $prefix);
         }
 
-        return self::underscoresToCamelCase($table, true);
+        $camel = self::underscoresToCamelCase($table, true);
+        $singular = self::safeSingular($camel);
+
+        return $singular;
     }
 
     /**
@@ -129,5 +132,22 @@ abstract class StringUtils
         }
 
         return $plural;
+    }
+
+    /**
+     * Use laravel singularization, and if that one fails give a warning.
+     *
+     * @param $value
+     *
+     * @return string
+     */
+    public static function safeSingular($value)
+    {
+        $singular = str_singular($value);
+        if ($singular == $value) {
+            echo 'warning: automatic singularization of '.$value.' failed, using '.$singular.LF;
+        }
+
+        return $singular;
     }
 }


### PR DESCRIPTION
Class names should be singular, camel case.
Table names should be plural, snake case.

http://laravel.com/docs/5.1/eloquent#eloquent-model-conventions
